### PR TITLE
Added VR-mode fullScreen/stereoscope effect button and functionality for the bargraph.

### DIFF
--- a/public/js/bars.js
+++ b/public/js/bars.js
@@ -48,8 +48,6 @@ function animate() {
 function render() {
   if (vrModeIsOn) {
     effect.render(scene, camera);
-
-    // effect.setFullScreen( true );
   }
   else {
     renderer.render(scene, camera);

--- a/public/js/bars.js
+++ b/public/js/bars.js
@@ -66,7 +66,7 @@ function addBar(x, y, z) {
   });
   geometry.colorsNeedUpdate = true;
   var mesh = new THREE.Mesh(geometry, material);
-  mesh.position.y = 1 + y/2;
+  mesh.position.y = 1 + y/2;;
   mesh.position.x = x - 500;
   mesh.position.z = z;
   scene.add(mesh);
@@ -80,7 +80,7 @@ function addBar(x, y, z) {
 
 function createDictionary(_json) {
   var uniqarr = _.uniq(_json.column_name);
-  return uniqarr;
+  return uniqarr
 }
 
 function renderData(data) {

--- a/public/js/bars.js
+++ b/public/js/bars.js
@@ -66,7 +66,7 @@ function addBar(x, y, z) {
   });
   geometry.colorsNeedUpdate = true;
   var mesh = new THREE.Mesh(geometry, material);
-  mesh.position.y = 1 + y/2;;
+  mesh.position.y = 1 + y/2;
   mesh.position.x = x - 500;
   mesh.position.z = z;
   scene.add(mesh);
@@ -80,7 +80,7 @@ function addBar(x, y, z) {
 
 function createDictionary(_json) {
   var uniqarr = _.uniq(_json.column_name);
-  return uniqarr
+  return uniqarr;
 }
 
 function renderData(data) {

--- a/public/js/bars.js
+++ b/public/js/bars.js
@@ -46,7 +46,14 @@ function animate() {
 }
 
 function render() {
-  renderer.render(scene, camera);
+  if (vrModeIsOn) {
+    effect.render(scene, camera);
+
+    // effect.setFullScreen( true );
+  }
+  else {
+    renderer.render(scene, camera);
+  }
 }
 
 

--- a/public/js/init.js
+++ b/public/js/init.js
@@ -10,7 +10,6 @@ var projector
 var targetlist
 var INTERSECTED
 var intersects
-var vrModeIsOn = false
 
 
 function init(){
@@ -248,30 +247,5 @@ function checkHighlight(){ //http://www.moczys.com/webGL/Experiment_02_V05.html
 }
 
 function fetchData(){
-
-}
-
-function enterVRMode(){
-	vrModeIsOn = true;
-	element = document.getElementsByClassName('visual')[0];
-	if ( navigator.userAgent.indexOf('Chrome') != -1 ){			//Chrome
-		element.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
-	}
-	else if (navigator.userAgent.indexOf('Firefox') != -1){		//Firefox
-		element.mozRequestFullScreen();
-	}
-}
-
-if (document.getElementsByClassName('visual')[0].addEventListener)
-{
-    document.getElementsByClassName('visual')[0].addEventListener('webkitfullscreenchange', fullScreenExitHandler, false);
-	document.getElementsByClassName('visual')[0].addEventListener('mozfullscreenchange', fullScreenExitHandler, false);
-	document.getElementsByClassName('visual')[0].addEventListener('fullscreenchange', fullScreenExitHandler, false);
-}
-
-function fullScreenExitHandler(){
-    if ( !(document.webkitIsFullScreen || document.mozFullScreen) ){
-    	vrModeIsOn = false;
-    }
 
 }

--- a/public/js/init.js
+++ b/public/js/init.js
@@ -10,6 +10,7 @@ var projector
 var targetlist
 var INTERSECTED
 var intersects
+var vrModeIsOn = false
 
 
 function init(){
@@ -247,5 +248,30 @@ function checkHighlight(){ //http://www.moczys.com/webGL/Experiment_02_V05.html
 }
 
 function fetchData(){
+
+}
+
+function enterVRMode(){
+	vrModeIsOn = true;
+	element = document.getElementsByClassName('visual')[0];
+	if ( navigator.userAgent.indexOf('Chrome') != -1 ){			//Chrome
+		element.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+	}
+	else if (navigator.userAgent.indexOf('Firefox') != -1){		//Firefox
+		element.mozRequestFullScreen();
+	}
+}
+
+if (document.getElementsByClassName('visual')[0].addEventListener)
+{
+    document.getElementsByClassName('visual')[0].addEventListener('webkitfullscreenchange', fullScreenExitHandler, false);
+	document.getElementsByClassName('visual')[0].addEventListener('mozfullscreenchange', fullScreenExitHandler, false);
+	document.getElementsByClassName('visual')[0].addEventListener('fullscreenchange', fullScreenExitHandler, false);
+}
+
+function fullScreenExitHandler(){
+    if ( !(document.webkitIsFullScreen || document.mozFullScreen) ){
+    	vrModeIsOn = false;
+    }
 
 }

--- a/public/js/vrDetection.js
+++ b/public/js/vrDetection.js
@@ -1,0 +1,66 @@
+/*
+This script allows the toggling of Virtual Reality Mode with the click of a button.
+With VR Mode on, the stereoscopic effect will be enabled and it will go into full screen.
+With VR Mode off, both will be disabled.
+
+For this script to work correctly, you need to do the following:
+
+	You need to have 2 renderings in your animation.
+	The base renderer:
+
+		renderer = new THREE.WebGLRenderer({ alpha: true });
+	  	renderer.setSize(window.innerWidth, window.innerHeight);
+
+	And the effect renderer:
+
+	  //add effect
+	  effect = new THREE.StereoEffect(renderer);
+	  effect.setSize( window.innerWidth, window.innerHeight );
+
+	Change your basic render() function:
+		
+		function render() {
+			renderer.render(scene, camera);
+		}
+
+	Into:
+
+		function render() {
+		  if (vrModeIsOn) {
+		    effect.render(scene, camera);
+		  }
+		  else {
+		    renderer.render(scene, camera);
+		  }
+		}
+
+See bars.js for reference.
+*/
+
+var vrModeIsOn = false
+
+function fullScreenExitHandler(){
+    if ( !(document.webkitIsFullScreen || document.mozFullScreen) ){
+    	vrModeIsOn = false;
+    }
+
+}
+
+if (document.getElementsByClassName('visual')[0].addEventListener)
+{
+    document.getElementsByClassName('visual')[0].addEventListener('webkitfullscreenchange', fullScreenExitHandler, false);
+	document.getElementsByClassName('visual')[0].addEventListener('mozfullscreenchange', fullScreenExitHandler, false);
+	document.getElementsByClassName('visual')[0].addEventListener('fullscreenchange', fullScreenExitHandler, false);
+}
+
+function enterVRMode(){
+	vrModeIsOn = true;
+	element = document.getElementsByClassName('visual')[0];
+	if ( navigator.userAgent.indexOf('Chrome') != -1 ){			//Chrome
+		element.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+	}
+	else if (navigator.userAgent.indexOf('Firefox') != -1){		//Firefox
+		element.mozRequestFullScreen();
+	}
+}
+

--- a/public/js/vrDetection.js
+++ b/public/js/vrDetection.js
@@ -3,8 +3,6 @@ This script allows the toggling of Virtual Reality Mode with the click of a butt
 With VR Mode on, the stereoscopic effect will be enabled and it will go into full screen.
 With VR Mode off, both will be disabled.
 
-//Bug: Exiting stereoscopic mode is buggy with Firefox. Works sometimes, other times doesnt.
-
 For this script to work correctly, you need to do the following:
 
 	You need to have 2 renderings in your animation.
@@ -20,7 +18,7 @@ For this script to work correctly, you need to do the following:
 	  effect.setSize( window.innerWidth, window.innerHeight );
 
 	Change your basic render() function:
-		
+
 		function render() {
 			renderer.render(scene, camera);
 		}
@@ -39,10 +37,9 @@ For this script to work correctly, you need to do the following:
 See bars.js for reference.
 */
 
-var vrModeIsOn = false
+var vrModeIsOn = false;
 
 function fullScreenExitHandler(){
-	console.log(document.mozFullScreen)
     if ( !(document.webkitIsFullScreen || document.mozFullScreen) ){
     	vrModeIsOn = false;
     }
@@ -50,9 +47,9 @@ function fullScreenExitHandler(){
 }
 
 if (document.getElementsByClassName('visual')[0].addEventListener)
-{	
+{
     document.getElementsByClassName('visual')[0].addEventListener('webkitfullscreenchange', fullScreenExitHandler, false);
-	document.addEventListener('mozfullscreenchange', fullScreenExitHandler, false);	
+	document.addEventListener('mozfullscreenchange', fullScreenExitHandler, false);
 }
 
 function enterVRMode(){

--- a/public/js/vrDetection.js
+++ b/public/js/vrDetection.js
@@ -3,6 +3,8 @@ This script allows the toggling of Virtual Reality Mode with the click of a butt
 With VR Mode on, the stereoscopic effect will be enabled and it will go into full screen.
 With VR Mode off, both will be disabled.
 
+//Bug: Exiting stereoscopic mode is buggy with Firefox. Works sometimes, other times doesnt.
+
 For this script to work correctly, you need to do the following:
 
 	You need to have 2 renderings in your animation.
@@ -40,6 +42,7 @@ See bars.js for reference.
 var vrModeIsOn = false
 
 function fullScreenExitHandler(){
+	console.log(document.mozFullScreen)
     if ( !(document.webkitIsFullScreen || document.mozFullScreen) ){
     	vrModeIsOn = false;
     }
@@ -47,10 +50,9 @@ function fullScreenExitHandler(){
 }
 
 if (document.getElementsByClassName('visual')[0].addEventListener)
-{
+{	
     document.getElementsByClassName('visual')[0].addEventListener('webkitfullscreenchange', fullScreenExitHandler, false);
-	document.getElementsByClassName('visual')[0].addEventListener('mozfullscreenchange', fullScreenExitHandler, false);
-	document.getElementsByClassName('visual')[0].addEventListener('fullscreenchange', fullScreenExitHandler, false);
+	document.addEventListener('mozfullscreenchange', fullScreenExitHandler, false);	
 }
 
 function enterVRMode(){

--- a/views/visualize.jade
+++ b/views/visualize.jade
@@ -44,8 +44,10 @@ block scripts
 	script(src='/js/OrbitControls.js')
 	script(src='/js/scatter.js')
 	script(src='/js/init.js')
+	script(src='/js/vrDetection.js')
 	script(src='/js/bars.js')
 	script(src='/js/StereoEffect.js')
+
 		
 
 

--- a/views/visualize.jade
+++ b/views/visualize.jade
@@ -33,7 +33,7 @@ block sidelist
 		li
 			input(type='button', value='Apply', onclick='generateBar()')
 			input(type='button', value='ApplyScatterPlot', onclick='generateScatter()')
-		
+			input(type='button', value='Enter VR', onclick='enterVRMode()')
 
 
 block scripts


### PR DESCRIPTION
Adds a button that can toggle Full screen and stereoscopic effect on bars.js.
Should be easy for scatterplot to add that in.

Note: The actual stereoscopic effect does not work so good. But we can solve that later.